### PR TITLE
Msrasheed/mavlink heartbeat

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "stm/persephone/mavlink_v2"]
+	path = stm/persephone/mavlink_v2
+	url = https://github.com/mavlink/c_library_v2.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "stm/persephone/mavlink"]
-	path = stm/persephone/mavlink
-	url = https://github.com/mavlink/c_library_v1.git

--- a/stm/persephone/CM4/.cproject
+++ b/stm/persephone/CM4/.cproject
@@ -49,6 +49,7 @@
 									<listOptionValue builtIn="false" value="../../Drivers/CMSIS/Include"/>
 									<listOptionValue builtIn="false" value="../../mavlink"/>
 									<listOptionValue builtIn="false" value="../../mavlink/common"/>
+									<listOptionValue builtIn="false" value="../../Common/Inc"/>
 								</option>
 								<inputType id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.input.c.1663891152" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.input.c"/>
 							</tool>

--- a/stm/persephone/CM4/.cproject
+++ b/stm/persephone/CM4/.cproject
@@ -47,9 +47,9 @@
 									<listOptionValue builtIn="false" value="../../Drivers/STM32H7xx_HAL_Driver/Inc/Legacy"/>
 									<listOptionValue builtIn="false" value="../../Drivers/CMSIS/Device/ST/STM32H7xx/Include"/>
 									<listOptionValue builtIn="false" value="../../Drivers/CMSIS/Include"/>
-									<listOptionValue builtIn="false" value="../../mavlink"/>
-									<listOptionValue builtIn="false" value="../../mavlink/common"/>
 									<listOptionValue builtIn="false" value="../../Common/Inc"/>
+									<listOptionValue builtIn="false" value="../../mavlink_v2"/>
+									<listOptionValue builtIn="false" value="../../mavlink_v2/common"/>
 								</option>
 								<inputType id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.input.c.1663891152" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.input.c"/>
 							</tool>

--- a/stm/persephone/CM4/Core/Src/main.c
+++ b/stm/persephone/CM4/Core/Src/main.c
@@ -22,6 +22,7 @@
 
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
+
 /* USER CODE END Includes */
 
 /* Private typedef -----------------------------------------------------------*/

--- a/stm/persephone/CM4/Core/Src/main.c
+++ b/stm/persephone/CM4/Core/Src/main.c
@@ -22,7 +22,7 @@
 
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
-
+uint8_t int_buff[263];
 /* USER CODE END Includes */
 
 /* Private typedef -----------------------------------------------------------*/

--- a/stm/persephone/CM4/Core/Src/main.c
+++ b/stm/persephone/CM4/Core/Src/main.c
@@ -22,7 +22,6 @@
 
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
-uint8_t int_buff[263];
 /* USER CODE END Includes */
 
 /* Private typedef -----------------------------------------------------------*/

--- a/stm/persephone/CM4/STM32H745ZITX_FLASH.ld
+++ b/stm/persephone/CM4/STM32H745ZITX_FLASH.ld
@@ -36,7 +36,7 @@
 ENTRY(Reset_Handler)
 
 /* Highest address of the user mode stack */
-_estack = 0x10048000;    /* end of RAM */
+_estack = 0x10040000;    /* end of RAM */
 /* Generate a link error if heap and stack don't fit into RAM */
 _Min_Heap_Size = 0x200 ;      /* required amount of heap  */
 _Min_Stack_Size = 0x400 ; /* required amount of stack */

--- a/stm/persephone/CM4/STM32H745ZITX_FLASH.ld
+++ b/stm/persephone/CM4/STM32H745ZITX_FLASH.ld
@@ -45,7 +45,7 @@ _Min_Stack_Size = 0x400 ; /* required amount of stack */
 MEMORY
 {
 FLASH (rx)      : ORIGIN = 0x08100000, LENGTH = 1024K
-RAM (xrw)      : ORIGIN = 0x10000000, LENGTH = 288K
+RAM (xrw)      : ORIGIN = 0x10000000, LENGTH = 262K
 }
 
 /* Define output sections */

--- a/stm/persephone/CM7/.cproject
+++ b/stm/persephone/CM7/.cproject
@@ -47,9 +47,9 @@
 									<listOptionValue builtIn="false" value="../../Drivers/STM32H7xx_HAL_Driver/Inc/Legacy"/>
 									<listOptionValue builtIn="false" value="../../Drivers/CMSIS/Device/ST/STM32H7xx/Include"/>
 									<listOptionValue builtIn="false" value="../../Drivers/CMSIS/Include"/>
-									<listOptionValue builtIn="false" value="../../mavlink"/>
-									<listOptionValue builtIn="false" value="../../mavlink/common"/>
 									<listOptionValue builtIn="false" value="../../Common/Inc"/>
+									<listOptionValue builtIn="false" value="../../mavlink_v2"/>
+									<listOptionValue builtIn="false" value="../../mavlink_v2/common"/>
 								</option>
 								<inputType id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.input.c.1906430706" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.input.c"/>
 							</tool>

--- a/stm/persephone/CM7/.cproject
+++ b/stm/persephone/CM7/.cproject
@@ -49,6 +49,7 @@
 									<listOptionValue builtIn="false" value="../../Drivers/CMSIS/Include"/>
 									<listOptionValue builtIn="false" value="../../mavlink"/>
 									<listOptionValue builtIn="false" value="../../mavlink/common"/>
+									<listOptionValue builtIn="false" value="../../Common/Inc"/>
 								</option>
 								<inputType id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.input.c.1906430706" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.input.c"/>
 							</tool>

--- a/stm/persephone/CM7/Core/Inc/main.h
+++ b/stm/persephone/CM7/Core/Inc/main.h
@@ -32,7 +32,7 @@ extern "C" {
 
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
-
+#include <mavlink_pssc.h>
 /* USER CODE END Includes */
 
 /* Exported types ------------------------------------------------------------*/

--- a/stm/persephone/CM7/Core/Src/main.c
+++ b/stm/persephone/CM7/Core/Src/main.c
@@ -118,7 +118,7 @@ int main(void)
   /* USER CODE BEGIN 2 */
 
 	mavlink_initialize();
-	// set_mavlink_msg_interval(0, 10000);
+	set_mavlink_msg_interval(MAVLINK_MSG_ID_TRAJECTORY_REPRESENTATION_WAYPOINTS, 10000);
 
 	//  /* USER CODE END 2 */
 	//

--- a/stm/persephone/CM7/Core/Src/main.c
+++ b/stm/persephone/CM7/Core/Src/main.c
@@ -117,43 +117,6 @@ int main(void)
   /* Initialize all configured peripherals */
   /* USER CODE BEGIN 2 */
 
-//	RCC->AHB4ENR |= RCC_AHB4ENR_GPIOBEN | RCC_AHB4ENR_GPIOCEN | RCC_AHB4ENR_GPIOAEN;
-//	GPIOB->MODER &= ~(GPIO_MODER_MODE14);
-//	GPIOB->MODER |= GPIO_MODER_MODE14_0;
-//	// GPIOB->ODR |= 1 << 14;
-//	GPIOC->MODER &= ~(GPIO_MODER_MODE13);
-//	// int i, mask = 1;
-//
-//	GPIOA->MODER &= ~(GPIO_MODER_MODE9 | GPIO_MODER_MODE10);
-//	GPIOA->MODER |= GPIO_MODER_MODE9_1 | GPIO_MODER_MODE10_1;
-//	GPIOA->AFR[1] &= ~(GPIO_AFRH_AFRH1 | GPIO_AFRH_AFRH2);
-//	GPIOA->AFR[1] |= (7 << 4) | (7 << 8);
-//
-//	RCC->APB2ENR |= RCC_APB2ENR_USART1EN;
-//	USART1->CR1 &= ~(USART_CR1_M0 | USART_CR1_M1); //1 start bit, 8 data bits, n stob bits
-//	USART1->BRR = 64000000 / 57600; // fixed?
-//	USART1->CR1 |= USART_CR1_RE | USART_CR1_TE; // enable rx and tx
-//	USART1->CR2 &= ~(USART_CR2_STOP); // 1 stop bit
-//	USART1->CR3 |= USART_CR3_DMAT;
-//	USART1->CR1 |= USART_CR1_UE;
-//
-//	RCC->AHB1ENR |= RCC_AHB1ENR_DMA1EN;
-//	DMA1_Stream0->CR |= DMA_MINC_ENABLE | DMA_SxCR_DIR_0 | DMA_SxCR_TRBUFF;
-//	DMA1_Stream0->NDTR = 12;
-//	DMA1_Stream0->PAR = (unsigned int) &USART1->TDR;
-//	DMA1_Stream0->M0AR = (unsigned int) Hello_Buff;
-//
-//	DMAMUX1_Channel0->CCR = 42; // uart1_tx_req42
-//	// DMA1_Stream0->CR |= DMA_SxCR_EN;
-//
-//	RCC->APB1LENR |= RCC_APB1LENR_TIM6EN;
-//	TIM6->PSC = 65000 - 1;
-//	TIM6->ARR = 1000;
-//	TIM6->DIER |= TIM_DIER_UIE;
-//
-//	NVIC_EnableIRQ(TIM6_DAC_IRQn);
-//	TIM6->CR1 |= TIM_CR1_CEN;
-
 	mavlink_initialize();
 	// set_mavlink_msg_interval(0, 10000);
 
@@ -163,10 +126,7 @@ int main(void)
 	//  /* USER CODE BEGIN WHILE */
 	while (1)
 	{
-//		for (i = 0;  i < 1000000; i++) {}
-//		GPIOB->ODR ^= (1 << 14) * mask;
-//		if (GPIOC->IDR != 0) mask = 0;
-//		else mask = 1;
+
 		/* USER CODE BEGIN 3 */
   }
   /* USER CODE END 3 */

--- a/stm/persephone/CM7/Core/Src/main.c
+++ b/stm/persephone/CM7/Core/Src/main.c
@@ -155,6 +155,8 @@ int main(void)
 //	TIM6->CR1 |= TIM_CR1_CEN;
 
 	mavlink_initialize();
+	set_mavlink_msg_interval(0, 10000);
+
 	//  /* USER CODE END 2 */
 	//
 	//  /* Infinite loop */

--- a/stm/persephone/CM7/Core/Src/main.c
+++ b/stm/persephone/CM7/Core/Src/main.c
@@ -155,7 +155,7 @@ int main(void)
 //	TIM6->CR1 |= TIM_CR1_CEN;
 
 	mavlink_initialize();
-	set_mavlink_msg_interval(0, 10000);
+	// set_mavlink_msg_interval(0, 10000);
 
 	//  /* USER CODE END 2 */
 	//

--- a/stm/persephone/CM7/Core/Src/main.c
+++ b/stm/persephone/CM7/Core/Src/main.c
@@ -19,7 +19,6 @@
 /* USER CODE END Header */
 /* Includes ------------------------------------------------------------------*/
 #include "main.h"
-#include <common/mavlink.h>
 
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
@@ -66,7 +65,7 @@ void SystemClock_Config(void);
 int main(void)
 {
   /* USER CODE BEGIN 1 */
-	mavlink_message_t msg;
+	//mavlink_message_t msg;
   /* USER CODE END 1 */
 
 	/* USER CODE BEGIN Boot_Mode_Sequence_0 */
@@ -118,37 +117,54 @@ int main(void)
   /* Initialize all configured peripherals */
   /* USER CODE BEGIN 2 */
 
-	RCC->AHB4ENR |= RCC_AHB4ENR_GPIOBEN | RCC_AHB4ENR_GPIOCEN | RCC_AHB4ENR_GPIOAEN;
-	GPIOB->MODER &= ~(0x30000000);
-	GPIOB->MODER |= 0x10000000;
-	GPIOB->ODR |= 1 << 14;
-	GPIOC->MODER &= ~(0xc000000);
-	int i, mask = 1;
+//	RCC->AHB4ENR |= RCC_AHB4ENR_GPIOBEN | RCC_AHB4ENR_GPIOCEN | RCC_AHB4ENR_GPIOAEN;
+//	GPIOB->MODER &= ~(GPIO_MODER_MODE14);
+//	GPIOB->MODER |= GPIO_MODER_MODE14_0;
+//	// GPIOB->ODR |= 1 << 14;
+//	GPIOC->MODER &= ~(GPIO_MODER_MODE13);
+//	// int i, mask = 1;
+//
+//	GPIOA->MODER &= ~(GPIO_MODER_MODE9 | GPIO_MODER_MODE10);
+//	GPIOA->MODER |= GPIO_MODER_MODE9_1 | GPIO_MODER_MODE10_1;
+//	GPIOA->AFR[1] &= ~(GPIO_AFRH_AFRH1 | GPIO_AFRH_AFRH2);
+//	GPIOA->AFR[1] |= (7 << 4) | (7 << 8);
+//
+//	RCC->APB2ENR |= RCC_APB2ENR_USART1EN;
+//	USART1->CR1 &= ~(USART_CR1_M0 | USART_CR1_M1); //1 start bit, 8 data bits, n stob bits
+//	USART1->BRR = 64000000 / 57600; // fixed?
+//	USART1->CR1 |= USART_CR1_RE | USART_CR1_TE; // enable rx and tx
+//	USART1->CR2 &= ~(USART_CR2_STOP); // 1 stop bit
+//	USART1->CR3 |= USART_CR3_DMAT;
+//	USART1->CR1 |= USART_CR1_UE;
+//
+//	RCC->AHB1ENR |= RCC_AHB1ENR_DMA1EN;
+//	DMA1_Stream0->CR |= DMA_MINC_ENABLE | DMA_SxCR_DIR_0 | DMA_SxCR_TRBUFF;
+//	DMA1_Stream0->NDTR = 12;
+//	DMA1_Stream0->PAR = (unsigned int) &USART1->TDR;
+//	DMA1_Stream0->M0AR = (unsigned int) Hello_Buff;
+//
+//	DMAMUX1_Channel0->CCR = 42; // uart1_tx_req42
+//	// DMA1_Stream0->CR |= DMA_SxCR_EN;
+//
+//	RCC->APB1LENR |= RCC_APB1LENR_TIM6EN;
+//	TIM6->PSC = 65000 - 1;
+//	TIM6->ARR = 1000;
+//	TIM6->DIER |= TIM_DIER_UIE;
+//
+//	NVIC_EnableIRQ(TIM6_DAC_IRQn);
+//	TIM6->CR1 |= TIM_CR1_CEN;
 
-	GPIOA->MODER &= ~(GPIO_MODER_MODE9 | GPIO_MODER_MODE10);
-	GPIOA->MODER |= GPIO_MODER_MODE9_1 | GPIO_MODER_MODE10_1;
-	GPIOA->AFR[1] &= ~(GPIO_AFRH_AFRH1 | GPIO_AFRH_AFRH2);
-	GPIOA->AFR[1] |= (7 << 4) | (7 << 8);
-
-	RCC->APB2ENR |= RCC_APB2ENR_USART1EN;
-	USART1->CR1 &= ~(USART_CR1_M0 | USART_CR1_M1); //1 start bit, 8 data bits, n stob bits
-	USART1->BRR = 64000000 / 57600; // fixed?
-	USART1->CR1 |= USART_CR1_RE | USART_CR1_TE; // enable rx and tx
-	USART1->CR2 &= ~(USART_CR2_STOP); // 1 stop bit
-	USART1->CR1 |= USART_CR1_UE;
-
-	USART1->TDR = 0xaa;
-
+	mavlink_initialize();
 	//  /* USER CODE END 2 */
 	//
 	//  /* Infinite loop */
 	//  /* USER CODE BEGIN WHILE */
 	while (1)
 	{
-		for (i = 0;  i < 1000000; i++) {}
-		GPIOB->ODR ^= (1 << 14) * mask;
-		if (GPIOC->IDR != 0) mask = 0;
-		else mask = 1;
+//		for (i = 0;  i < 1000000; i++) {}
+//		GPIOB->ODR ^= (1 << 14) * mask;
+//		if (GPIOC->IDR != 0) mask = 0;
+//		else mask = 1;
 		/* USER CODE BEGIN 3 */
   }
   /* USER CODE END 3 */

--- a/stm/persephone/CM7/Core/Src/main.c
+++ b/stm/persephone/CM7/Core/Src/main.c
@@ -118,7 +118,7 @@ int main(void)
   /* USER CODE BEGIN 2 */
 
 	mavlink_initialize();
-	set_mavlink_msg_interval(MAVLINK_MSG_ID_TRAJECTORY_REPRESENTATION_WAYPOINTS, 10000);
+	// set_mavlink_msg_interval(MAVLINK_MSG_ID_TRAJECTORY_REPRESENTATION_WAYPOINTS, 10000);
 
 	//  /* USER CODE END 2 */
 	//

--- a/stm/persephone/CM7/STM32H745ZITX_FLASH.ld
+++ b/stm/persephone/CM7/STM32H745ZITX_FLASH.ld
@@ -47,6 +47,7 @@ MEMORY
 FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 1024K
 RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 128K
 ITCMRAM (xrw)      : ORIGIN = 0x00000000, LENGTH = 64K
+RAM3 (xrw)      : ORIGIN = 0x10040000, LENGTH = 32K
 }
 
 /* Define output sections */
@@ -157,7 +158,10 @@ SECTIONS
     . = ALIGN(8);
   } >RAM
 
-  
+  .dma_buffer :
+  {
+    *(.dma_buffer)
+  } >RAM3
 
   /* Remove information from the standard libraries */
   /DISCARD/ :

--- a/stm/persephone/Common/Inc/mavlink_pssc.h
+++ b/stm/persephone/Common/Inc/mavlink_pssc.h
@@ -15,5 +15,7 @@
 #include <common/mavlink.h>
 
 uint8_t mavlink_initialize(void);
+uint8_t set_mavlink_msg_interval(uint16_t message_id, int32_t interval_us) {
+
 
 #endif /* INC_MAVLINK_PSSC_H_ */

--- a/stm/persephone/Common/Inc/mavlink_pssc.h
+++ b/stm/persephone/Common/Inc/mavlink_pssc.h
@@ -1,0 +1,19 @@
+/*
+ * mavlink_pscc.h
+ *
+ *  Created on: Sep 28, 2020
+ *      Author: moiz
+ *
+ *  Description: mavlink implementation:
+ *  Requirments: USART1, TIM6, DAC1_Stream0
+ */
+
+#ifndef INC_MAVLINK_PSSC_H_
+#define INC_MAVLINK_PSSC_H_
+
+#include <stm32h7xx_hal.h>
+#include <common/mavlink.h>
+
+uint8_t mavlink_initialize(void);
+
+#endif /* INC_MAVLINK_PSSC_H_ */

--- a/stm/persephone/Common/Inc/mavlink_pssc.h
+++ b/stm/persephone/Common/Inc/mavlink_pssc.h
@@ -15,7 +15,7 @@
 #include <common/mavlink.h>
 
 uint8_t mavlink_initialize(void);
-uint8_t set_mavlink_msg_interval(uint16_t message_id, int32_t interval_us) {
+uint8_t set_mavlink_msg_interval(uint16_t message_id, int32_t interval_us);
 
 
 #endif /* INC_MAVLINK_PSSC_H_ */

--- a/stm/persephone/Common/Inc/mavlink_pssc.h
+++ b/stm/persephone/Common/Inc/mavlink_pssc.h
@@ -14,7 +14,12 @@
 #include <stm32h7xx_hal.h>
 #include <common/mavlink.h>
 
+// initializes all IO and starts sending the
+// heartbeat message at a rate of 1Hz
 uint8_t mavlink_initialize(void);
+
+// will send a message to flight controller instructing it to send
+// the message_id specified at the interval specified
 uint8_t set_mavlink_msg_interval(uint16_t message_id, int32_t interval_us);
 
 

--- a/stm/persephone/Common/Src/mavlink_pssc.c
+++ b/stm/persephone/Common/Src/mavlink_pssc.c
@@ -12,6 +12,7 @@ __attribute__((section(".dma_buffer"))) uint8_t _msg_buff[263];
 mavlink_message_t _rcv_msg;
 mavlink_status_t _rcv_msg_stat;
 mavlink_heartbeat_t _rcv_msg_heartbeat;
+mavlink_trajectory_representation_waypoints_t _rcv_msg_traj_way;
 
 uint8_t _initialize_UART_DMA(void) {
 	RCC->AHB4ENR |= RCC_AHB4ENR_GPIOAEN | RCC_AHB4ENR_GPIOBEN;
@@ -99,7 +100,8 @@ uint8_t parse_mavlink_message(mavlink_message_t *msg) {
 		case MAVLINK_MSG_ID_HEARTBEAT:
 			mavlink_msg_heartbeat_decode(msg, &_rcv_msg_heartbeat);
 			break;
-		case MAVLINK_MSG_ID_SYS_STATUS:
+		case MAVLINK_MSG_ID_TRAJECTORY_REPRESENTATION_WAYPOINTS:
+			mavlink_msg_trajectory_representation_waypoints_decode(msg, &_rcv_msg_traj_way);
 			break;
 	}
 	return 0;

--- a/stm/persephone/Common/Src/mavlink_pssc.c
+++ b/stm/persephone/Common/Src/mavlink_pssc.c
@@ -1,0 +1,86 @@
+#include <mavlink_pssc.h>
+
+mavlink_system_t mavlink_system = {
+		1, // System ID (0-255)
+		MAV_COMP_ID_ONBOARD_COMPUTER // Computer ID (a MAV_COMPONENT value)
+};
+
+mavlink_message_t _hb_msg;
+__attribute__((section(".dma_buffer"))) uint8_t msg_buff[263];
+
+uint8_t _initialize_UART_DMA(void) {
+	RCC->AHB4ENR |= RCC_AHB4ENR_GPIOAEN | RCC_AHB4ENR_GPIOBEN;
+	GPIOB->MODER &= ~(GPIO_MODER_MODE14);
+	GPIOB->MODER |= GPIO_MODER_MODE14_0;
+
+	GPIOA->MODER &= ~(GPIO_MODER_MODE9 | GPIO_MODER_MODE10);
+	GPIOA->MODER |= GPIO_MODER_MODE9_1 | GPIO_MODER_MODE10_1;
+	GPIOA->AFR[1] &= ~(GPIO_AFRH_AFRH1 | GPIO_AFRH_AFRH2);
+	GPIOA->AFR[1] |= (7 << 4) | (7 << 8);
+
+	RCC->APB2ENR |= RCC_APB2ENR_USART1EN;
+	USART1->CR1 &= ~(USART_CR1_M0 | USART_CR1_M1); //1 start bit, 8 data bits, n stob bits
+	USART1->BRR = 64000000 / 57600; // fixed?
+	USART1->CR1 |= USART_CR1_RE | USART_CR1_TE; // enable rx and tx
+	USART1->CR2 &= ~(USART_CR2_STOP); // 1 stop bit
+	USART1->CR3 |= USART_CR3_DMAT;
+	USART1->CR1 |= USART_CR1_UE;
+
+	RCC->AHB1ENR |= RCC_AHB1ENR_DMA1EN;
+	DMA1_Stream0->CR |= DMA_MINC_ENABLE | DMA_SxCR_DIR_0 | DMA_SxCR_TRBUFF;
+	DMA1_Stream0->PAR = (unsigned int) &USART1->TDR;
+
+	DMAMUX1_Channel0->CCR = 42; // uart1_tx_req42
+	// DMA1_Stream0->CR |= DMA_SxCR_EN;
+
+	RCC->APB1LENR |= RCC_APB1LENR_TIM6EN;
+	TIM6->PSC = 65000 - 1;
+	TIM6->ARR = 1000;
+	TIM6->DIER |= TIM_DIER_UIE;
+
+	NVIC_EnableIRQ(TIM6_DAC_IRQn);
+	TIM6->CR1 |= TIM_CR1_CEN;
+
+	return 0;
+}
+
+uint8_t _heartbeat_msg_initialize(void) {
+  mavlink_msg_heartbeat_pack(mavlink_system.sysid, 			 // system_id
+                             mavlink_system.compid,			 // component_id
+                             &_hb_msg,                  		 // mavlink_message_t
+                             MAV_TYPE_QUADROTOR,   			 // MAV_TYPE
+                             MAV_AUTOPILOT_PX4,    			 // MAV_AUTOPILOT
+                             MAV_MODE_FLAG_AUTO_ENABLED, // base_mode
+                             0,                    			 // custom_mode
+                             MAV_STATE_ACTIVE      			 // system_status
+                             );
+  return 0;
+}
+
+uint8_t mavlink_initialize(void) {
+	_initialize_UART_DMA();
+	_heartbeat_msg_initialize();
+	return 0;
+}
+
+uint8_t send_mavlink_message(mavlink_message_t *msg) {
+	while ((DMA1_Stream0->CR & 0x1) == 1) {}
+	DMA1->LIFCR |= DMA_LIFCR_CTCIF0 | DMA_LIFCR_CHTIF0 | DMA_LIFCR_CFEIF0 | DMA_LIFCR_CTEIF0;
+	uint8_t * pointer = msg_buff;
+	mavlink_msg_to_send_buffer(msg_buff, msg);
+	DMA1_Stream0->NDTR = msg->len + 12;
+	DMA1_Stream0->M0AR = (unsigned int) msg_buff;
+  DMA1_Stream0->CR |= DMA_SxCR_EN;
+  return 0;
+}
+
+void TIM6_DAC_IRQHandler() {
+	TIM6->SR &= ~TIM_SR_UIF; // Need to put clear flag up hear, or at least before on other instruction (not directly by bracket)
+	// otherwise NVIC will not register and IRQHandler will fire again.
+
+	GPIOB->ODR ^= GPIO_ODR_OD14;
+	send_mavlink_message(&_hb_msg);
+	// DMA1_Stream0->NDTR = 12;
+
+	//TIM6->CR1 &= TIM_CR1_CEN;
+}

--- a/stm/persephone/Common/Src/mavlink_pssc.c
+++ b/stm/persephone/Common/Src/mavlink_pssc.c
@@ -99,6 +99,8 @@ uint8_t parse_mavlink_message(mavlink_message_t *msg) {
 		case MAVLINK_MSG_ID_HEARTBEAT:
 			mavlink_msg_heartbeat_decode(msg, &_rcv_msg_heartbeat);
 			break;
+		case MAVLINK_MSG_ID_SYS_STATUS:
+			break;
 	}
 	return 0;
 }


### PR DESCRIPTION
# Mavlink heartbeat send/receive

## Description

This pull request includes the code required to send a mavlink heartbeat message from the stm at a rate of 1Hz and is able to receive and unpack the heartbeat message from the flight controller. 
Currently, it uses DMA transfers to transmit over USART1. If a DMA transfer is ongoing and a new call to `send_mavlink_message` is called, it will block. If there is no current DMA transfer, then it is non blocking. 
Reception of mavlink packets over USART1 are done with a interrupt whenever the RXNE flag is raised. The interrupt then passes the char to the mavlink helper function to parse the incoming bytes for the message. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Observed heartbeat messages were being sent by stm on Oscilloscope since the pixhawk just ignores them (I read on a forum post somewhere). Observed outgoing messages from pixhawk on oscilloscope and was able to confirm with debugger that stm was parsing and unpacking heartbeat message successfully. 

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
